### PR TITLE
Add a `yorm.fake` setting to bypass the filesystem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ $(ALL): $(SOURCES)
 	touch $(ALL)  # flag to indicate all setup steps were successful
 
 .PHONY: ci
-ci: pep8 pep257 test tests
+ci: pep8 pep257 pylint test tests
 
 .PHONY: demo
 demo: env

--- a/yorm/__init__.py
+++ b/yorm/__init__.py
@@ -7,6 +7,8 @@ __version__ = '0.2-dev'
 
 VERSION = __project__ + '-' + __version__
 
+fake = False
+
 try:
     from . import standard, extended, container
     from .utilities import UUID, store, store_instances, map_attr

--- a/yorm/test/test_fake.py
+++ b/yorm/test/test_fake.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+# pylint:disable=R0201
+
+"""Integration tests for the `yorm.fake` option."""
+
+import pytest
+from unittest.mock import patch
+
+import yorm  # pylint: disable=W0611
+
+
+@patch('yorm.fake', True)
+class TestFakeEnabled:
+
+    """Integration tests with `yorm.fake` enabled."""
+
+    # TODO: add a sample class here
+
+    # TODO: add tests here
+
+
+if __name__ == '__main__':
+    pytest.main()


### PR DESCRIPTION
- [ ] create a `yorm.fake` boolean that defaults to false
- [ ] add a `yorm_text` attribute to mapped objects that contains the text
- [ ] if `yorm.fake` is set, `yorm_text` should not be:
  - [ ] written to the filesystem
  - [ ] read from the filesystem
