### PR TITLE
Update APIs to new names

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+CHANGES.md merge=union

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,12 @@ Changelog
 ---------
 
 - Updated mapped objects to only read from the filesystem if there are changes.
+- Renamed `store` to `sync_object`.
+- Renamed `store_instances` to `sync_instances`.
+- Renamed `map_attr` to `attr`.
+- Added `sync` to call `sync_object` or `sync_instances` as needed.
+- Added `update_object` and `update_file` to force syncrhonization.
+- Added `update` to call `update_object` and/or `update_file` as needed.
 
 0.2.1 (2015-2-12)
 -----------------

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ ifndef TEST_RUNNER
 	# options are: nose, pytest
 	TEST_RUNNER := pytest
 endif
-UNIT_TEST_COVERAGE := 97
+UNIT_TEST_COVERAGE := 98
 INTEGRATION_TEST_COVERAGE := 100
 
 # Project settings

--- a/README.md
+++ b/README.md
@@ -30,13 +30,17 @@ Installation
 
 YORM can be installed with pip:
 
-    $ pip install YORM
+```
+$ pip install YORM
+```
 
-Or directly from the source code:
+or directly from the source code:
 
-    $ git clone https://github.com/jacebrowning/yorm.git
-    $ cd yorm
-    $ python setup.py install
+```
+$ git clone https://github.com/jacebrowning/yorm.git
+$ cd yorm
+$ python setup.py install
+```
 
 Basic Usage
 ===========
@@ -57,15 +61,15 @@ class Student:
 and define an attribute mapping:
 
 ```python
-from yorm import store_instances, map_attr
+import yorm
 from yorm.standard import String, Integer, Float
 
-@map_attr(name=String, year=Integer, gpa=Float)
-@store_instances("students/{self.school}/{self.number}.yml")
+@yorm.attr(name=String, year=Integer, gpa=Float)
+@yorm.sync("students/{self.school}/{self.number}.yml")
 class Student: ...
 ```
 
-Modifications to an object's mapped attributes:
+Modifications to each object's mapped attributes:
 
 ```python
 >>> s1 = Student("John Doe", "GVSU", 123)
@@ -83,7 +87,7 @@ school: GVSU
 year: 2009
 ```
 
-Modifications and new content in the mapped file:
+Modifications and new content in each mapped file:
 
 ```bash
 $ echo "name: John Doe
@@ -93,7 +97,7 @@ $ echo "name: John Doe
 " > students/GVSU/123.yml
 ```
 
-are automatically reflected in the objects:
+are automatically reflected in the corresponding object:
 
 ```python
 >>> s1.gpa
@@ -108,7 +112,7 @@ For Contributors
 Requirements
 ------------
 
-* GNU Make:
+* Make:
     * Windows: http://cygwin.com/install.html
     * Mac: https://developer.apple.com/xcode
     * Linux: http://www.gnu.org/software/make (likely already installed)
@@ -121,25 +125,35 @@ Installation
 
 Create a virtualenv:
 
-    $ make env
+```
+$ make env
+```
 
 Run the tests:
 
-    $ make test
-    $ make tests  # includes integration tests
+```
+$ make test
+$ make tests  # includes integration tests
+```
 
 Build the documentation:
 
-    $ make doc
+```
+$ make doc
+```
 
 Run static analysis:
 
-    $ make pep8
-    $ make pep257
-    $ make pylint
-    $ make check  # includes all checks
+```
+$ make pep8
+$ make pep257
+$ make pylint
+$ make check  # includes all checks
+```
 
 Prepare a release:
 
-    $ make dist  # dry run
-    $ make upload
+```
+$ make dist  # dry run
+$ make upload
+```

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ YORM
 
 YORM provides functions and decorators to enable automatic, bidirectional, and human-friendly mappings of Python object attributes to YAML files.
 
-Uses beyond typical object serialization and object mapping include:
+Uses beyond typical object serialization and mapping include:
 
-* automatic bidirectional conversion of attributes types
+* bidirectional conversion between basic YAML and Python types
 * attribute creation and type inference for new attributes
 * storage of content in text files optimized for version control
-* custom converters to map complex classes to JSON-compatible types
+* extensible converters to customize formatting on complex classes
 
 
 Getting Started
@@ -97,7 +97,7 @@ $ echo "name: John Doe
 " > students/GVSU/123.yml
 ```
 
-are automatically reflected in the corresponding object:
+are automatically reflected in their corresponding object:
 
 ```python
 >>> s1.gpa

--- a/examples/demo.ipynb
+++ b/examples/demo.ipynb
@@ -1,93 +1,109 @@
 {
- "metadata": {
-  "name": "",
-  "signature": "sha256:843b0edc033d9630b37ca635827d82dc27dbf596805ff39df082b65a22d02f3a"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "import logging\n",
-      "logger = logging.getLogger()\n",
-      "logger.setLevel(logging.DEBUG-1)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "import yorm"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "class Student:\n",
-      "    \n",
-      "    def __init__(self, name, number, graduated=False):\n",
-      "        self.name = name\n",
-      "        self.number = number\n",
-      "        self.graduated = graduated\n",
-      "        \n",
-      "    def __repr__(self):\n",
-      "        return \"<student {}>\".format(self.number)\n",
-      "        \n",
-      "    def graduate(self):\n",
-      "        self.graduated = True"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "@yorm.map_attr(name=yorm.standard.String)\n",
-      "@yorm.map_attr(graduated=yorm.standard.Boolean)\n",
-      "@yorm.store_instances(\"students/{n}.yml\", {'n': 'number'})\n",
-      "class MappedStudent(Student):\n",
-      "    \n",
-      "    pass"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "s1 = MappedStudent(\"John Doe\", 123)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "s2 = MappedStudent(\"Jane Doe\", 456, graduated=True)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    }
-   ],
-   "metadata": {}
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "logger = logging.getLogger()\n",
+    "logger.setLevel(logging.DEBUG)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import yorm"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "class Student:\n",
+    "    \n",
+    "    def __init__(self, name, number, graduated=False):\n",
+    "        self.name = name\n",
+    "        self.number = number\n",
+    "        self.graduated = graduated\n",
+    "        \n",
+    "    def __repr__(self):\n",
+    "        return \"<student {}>\".format(self.number)\n",
+    "        \n",
+    "    def graduate(self):\n",
+    "        self.graduated = True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "@yorm.attr(name=yorm.standard.String)\n",
+    "@yorm.attr(graduated=yorm.standard.Boolean)\n",
+    "@yorm.sync(\"students/{n}.yml\", {'n': 'number'})\n",
+    "class MappedStudent(Student):\n",
+    "    \n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "s1 = MappedStudent(\"John Doe\", 123)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "s2 = MappedStudent(\"Jane Doe\", 456, graduated=True)"
+   ]
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.4.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
-"""
-Setup script for YORM.
-"""
+"""Setup script for YORM."""
 
 import setuptools
 
@@ -32,7 +30,7 @@ setuptools.setup(
     long_description=(README + '\n' + CHANGES),
     license='MIT',
     classifiers=[
-        'Development Status :: 3 - Alpha',
+        'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',

--- a/yorm/__init__.py
+++ b/yorm/__init__.py
@@ -14,7 +14,9 @@ if not sys.version_info >= PYTHON_VERSION:  # pragma: no cover (manual test)
 
 try:
     from . import standard, extended, container
-    from .utilities import UUID, store, store_instances, map_attr
+    from .utilities import UUID
+    from .utilities import sync, sync_object, sync_instances, attr
+    from .utilities import update, update_object, update_file
     from .base import Mappable, Converter
 except ImportError:  # pragma: no cover (manual test)
     pass

--- a/yorm/base.py
+++ b/yorm/base.py
@@ -18,11 +18,11 @@ class Mappable(metaclass=abc.ABCMeta):  # pylint:disable=R0921
         try:
             value = object.__getattribute__(self, name)
         except AttributeError:
-            self.yorm_mapper.retrieve(self, self.yorm_attrs)
+            self.yorm_mapper.fetch(self, self.yorm_attrs)
             value = object.__getattribute__(self, name)
         else:
             if name in self.yorm_attrs:
-                self.yorm_mapper.retrieve(self, self.yorm_attrs)
+                self.yorm_mapper.fetch(self, self.yorm_attrs)
                 value = object.__getattribute__(self, name)
 
         return value

--- a/yorm/mapper.py
+++ b/yorm/mapper.py
@@ -75,14 +75,15 @@ class Mapper:
         self.exists = True
 
     @readwrite
-    def fetch(self, obj, attrs):
+    def fetch(self, obj, attrs, force=False):
         """Update the object's mapped attributes from its file."""
         if self._storing:
             return
-        if not self.modified:
+        if not self.modified and not force:
             return
         self._retrieving = True
-        log.debug("retrieving %r from %s'%s'...", obj, self._fake, self.path)
+        log.debug("%sfetching %r from %s'%s'...", "force-" if force else "",
+                  obj, self._fake, self.path)
 
         # Parse data from file
         if self._fake:
@@ -102,7 +103,7 @@ class Mapper:
                 converter = standard.match(name, data)
                 attrs[name] = converter
             value = converter.to_value(data)
-            log.trace("value retrieved: '{}' = {}".format(name, repr(value)))
+            log.trace("value fetched: '{}' = {}".format(name, repr(value)))
             setattr(obj, name, value)
 
         # Set meta attributes

--- a/yorm/mapper.py
+++ b/yorm/mapper.py
@@ -34,9 +34,9 @@ class Mapper:
 
     When getting an attribute:
 
-        FILE -> read -> [text] -> load -> [dict] -> retrieve -> ATTRIBUTES
+        FILE -> read -> [text] -> load -> [dict] -> fetch -> ATTRIBUTES
 
-    When settings an attribute:
+    When setting an attribute:
 
         ATTRIBUTES -> store -> [dict] -> dump -> [text] -> write -> FILE
 
@@ -75,8 +75,8 @@ class Mapper:
         self.exists = True
 
     @readwrite
-    def retrieve(self, obj, attrs):
-        """Load the object's mapped attributes from its file."""
+    def fetch(self, obj, attrs):
+        """Update the object's mapped attributes from its file."""
         if self._storing:
             return
         if not self.modified:

--- a/yorm/test/test_all.py
+++ b/yorm/test/test_all.py
@@ -180,7 +180,7 @@ class SampleExtended:
         return "<extended {}>".format(id(self))
 
 
-@store_instances("path/to/directory/{UUID}.yml", mapping={'level': Level})
+@store_instances("path/to/directory/{UUID}.yml", attrs={'level': Level})
 class SampleCustomDecorated:
 
     """Sample class using custom attribute types."""
@@ -204,22 +204,32 @@ def refresh_file_modification_times(seconds=1.1):
 
 
 def test_imports():
-    """Verify the package namespace is mapped correctly."""
+    """Verify the package namespace is correct."""
     # pylint: disable=W0404,W0612,W0621
+
     import yorm
 
-    from yorm import UUID, store, store_instances, map_attr
-    from yorm import Mappable, Converter
+    # Constants
+    from yorm import UUID  # filename placeholder
 
-    from yorm.standard import String
-    from yorm.extended import Markdown
-    from yorm.container import List
+    # Classes
+    from yorm import Mappable  # base class for mapped objects
+    from yorm import Converter  # base class for converters
+    from yorm.standard import String  # and others
+    from yorm.extended import Markdown  # and others
+    from yorm.container import List  # and others
 
-    assert store
-    assert Converter
-    assert yorm.standard.Boolean
-    assert yorm.extended.Markdown
-    assert yorm.container.Dictionary
+    # Decorators
+    from yorm import sync  # enables mapping on a class's instance objects
+    from yorm import sync_instances  # alias for the class decorator
+    from yorm import attr  # alternate API to identify mapped attributes
+
+    # Functions
+    from yorm import sync  # enables mapping on an instance object
+    from yorm import sync_object  # alias for the mapping function
+    from yorm import update  # fetch (if necessary) and store a mapped object
+    from yorm import update_object  # fetch (optional force) a mapped object
+    from yorm import update_file  # store a mapped object
 
 
 @integration

--- a/yorm/test/test_all.py
+++ b/yorm/test/test_all.py
@@ -8,7 +8,7 @@ import logging
 
 import pytest
 
-from yorm import store, store_instances, map_attr, Converter
+from yorm import sync, attr, Converter
 from yorm.container import Dictionary, List
 from yorm.standard import Object, String, Integer, Float, Boolean
 from yorm.extended import Markdown
@@ -50,25 +50,25 @@ class EmptyDictionary(Dictionary):
     """Sample dictionary container."""
 
 
-@map_attr(key=String)
+@attr(key=String)
 class SingleKeyDictionary(Dictionary):
 
     """Sample dictionary container."""
 
 
-@map_attr(all=Integer)
+@attr(all=Integer)
 class IntegerList(List):
 
     """Sample list container."""
 
 
-@map_attr(status=Boolean, label=String)
+@attr(status=Boolean, label=String)
 class StatusDictionary(Dictionary):
 
     """Sample dictionary container."""
 
 
-@map_attr(all=StatusDictionary)
+@attr(all=StatusDictionary)
 class StatusDictionaryList(List):
 
     """Sample list container."""
@@ -108,10 +108,10 @@ class SampleNested:
         return "<nested {}>".format(id(self))
 
 
-@map_attr(object=EmptyDictionary, array=IntegerList, string=String)
-@map_attr(number_int=Integer, number_real=Float)
-@map_attr(true=Boolean, false=Boolean)
-@store_instances("path/to/{self.category}/{self.name}.yml")
+@attr(object=EmptyDictionary, array=IntegerList, string=String)
+@attr(number_int=Integer, number_real=Float)
+@attr(true=Boolean, false=Boolean)
+@sync("path/to/{self.category}/{self.name}.yml")
 class SampleStandardDecorated:
 
     """Sample class using standard attribute types."""
@@ -133,8 +133,8 @@ class SampleStandardDecorated:
         return "<decorated {}>".format(id(self))
 
 
-@map_attr(string=String, number_real=Float)
-@store_instances("sample.yml", auto=False)
+@attr(string=String, number_real=Float)
+@sync("sample.yml", auto=False)
 class SampleDecoratedNoAuto:
 
     """Sample class with automatic storage turned off."""
@@ -147,7 +147,7 @@ class SampleDecoratedNoAuto:
         return "<no auto {}>".format(id(self))
 
 
-@map_attr(string=String, number_real=Float)
+@attr(string=String, number_real=Float)
 class SampleDecoratedNoPath:
 
     """Sample class with a manually mapped path."""
@@ -160,7 +160,7 @@ class SampleDecoratedNoPath:
         return "<no path {}>".format(id(self))
 
 
-@store_instances("sample.yml")
+@sync("sample.yml")
 class SampleEmptyDecorated:
 
     """Sample class using standard attribute types."""
@@ -180,7 +180,7 @@ class SampleExtended:
         return "<extended {}>".format(id(self))
 
 
-@store_instances("path/to/directory/{UUID}.yml", attrs={'level': Level})
+@sync("path/to/directory/{UUID}.yml", attrs={'level': Level})
 class SampleCustomDecorated:
 
     """Sample class using custom attribute types."""
@@ -307,14 +307,14 @@ class TestStandard:
         """Verify standard attribute types dump/load correctly (function)."""
         tmpdir.chdir()
         _sample = SampleStandard()
-        mapping = {'object': SingleKeyDictionary,
-                   'array': IntegerList,
-                   'string': String,
-                   'number_int': Integer,
-                   'number_real': Float,
-                   'true': Boolean,
-                   'false': Boolean}
-        sample = store(_sample, "path/to/directory/sample.yml", mapping)
+        attrs = {'object': SingleKeyDictionary,
+                 'array': IntegerList,
+                 'string': String,
+                 'number_int': Integer,
+                 'number_real': Float,
+                 'true': Boolean,
+                 'false': Boolean}
+        sample = sync(_sample, "path/to/directory/sample.yml", attrs)
         assert "path/to/directory/sample.yml" == sample.yorm_path
 
         # check defaults
@@ -358,9 +358,9 @@ class TestStandard:
         """Verify standard attribute types dump/load correctly (with)."""
         tmpdir.chdir()
         _sample = SampleStandard()
-        mapping = {'string': String,
-                   'number_real': Float}
-        sample = store(_sample, "sample.yml", mapping, auto=False)
+        attrs = {'string': String,
+                 'number_real': Float}
+        sample = sync(_sample, "sample.yml", attrs, auto=False)
 
         # change object values
         with sample:
@@ -409,7 +409,7 @@ class TestStandard:
     def test_no_path(self, tmpdir):
         """Verify standard attribute types dump/load correctly (path)."""
         tmpdir.chdir()
-        sample = store(SampleDecoratedNoPath(), "sample.yml")
+        sample = sync(SampleDecoratedNoPath(), "sample.yml")
 
         # change object values
         sample.string = "abc"
@@ -433,9 +433,9 @@ class TestContainers:
         """Verify standard attribute types can be nested."""
         tmpdir.chdir()
         _sample = SampleNested()
-        mapping = {'count': Integer,
-                   'results': StatusDictionaryList}
-        sample = store(_sample, "sample.yml", mapping)
+        attrs = {'count': Integer,
+                 'results': StatusDictionaryList}
+        sample = sync(_sample, "sample.yml", attrs)
 
         # check defaults
         assert 0 == sample.count
@@ -503,7 +503,7 @@ class TestContainers:
             stream.write(text)
 
         # (a mapped attribute must be read first to trigger retrieving)
-        sample.yorm_mapper.retrieve(sample, sample.yorm_attrs)
+        sample.yorm_mapper.fetch(sample, sample.yorm_attrs)
 
         # check object values
         assert {'key': 'value'} == sample.object
@@ -535,8 +535,8 @@ class TestExtended:
         """Verify extended attribute types dump/load correctly."""
         tmpdir.chdir()
         _sample = SampleExtended()
-        mapping = {'text': Markdown}
-        sample = store(_sample, "path/to/directory/sample.yml", mapping)
+        attrs = {'text': Markdown}
+        sample = sync(_sample, "path/to/directory/sample.yml", attrs)
 
         # check defaults
         assert "" == sample.text

--- a/yorm/test/test_all.py
+++ b/yorm/test/test_all.py
@@ -612,8 +612,8 @@ class TestInit:
 
     """Integration tests for initializing mapped classes."""
 
-    def test_retrieve_from_existing(self, tmpdir):
-        """Verify attributes are loaded from an existing file."""
+    def test_fetch_from_existing(self, tmpdir):
+        """Verify attributes are updated from an existing file."""
         tmpdir.chdir()
         sample = SampleStandardDecorated('sample')
         sample2 = SampleStandardDecorated('sample')

--- a/yorm/test/test_container.py
+++ b/yorm/test/test_container.py
@@ -5,7 +5,7 @@
 
 import pytest
 
-from yorm.utilities import map_attr
+from yorm.utilities import attr
 from yorm.container import Dictionary, List
 from yorm.standard import String, Integer
 
@@ -13,13 +13,13 @@ from yorm.standard import String, Integer
 # sample classes ##############################################################
 
 
-@map_attr(abc=Integer)
+@attr(abc=Integer)
 class SampleDictionary(Dictionary):
 
     """Sample dictionary container."""
 
 
-@map_attr(var1=Integer, var2=String)
+@attr(var1=Integer, var2=String)
 class SampleDictionaryWithInitialization(Dictionary):
 
     """Sample dictionary container with initialization."""
@@ -31,7 +31,7 @@ class SampleDictionaryWithInitialization(Dictionary):
         self.var3 = var3
 
 
-@map_attr(all=String)
+@attr(all=String)
 class StringList(List):
 
     """Sample list container."""

--- a/yorm/test/test_extended.py
+++ b/yorm/test/test_extended.py
@@ -5,7 +5,7 @@
 
 import pytest
 
-from yorm.utilities import map_attr
+from yorm.utilities import attr
 from yorm.extended import Markdown, AttributeDictionary, SortedList
 from yorm.standard import Integer, String, Float
 
@@ -13,7 +13,7 @@ from yorm.standard import Integer, String, Float
 # sample classes ##############################################################
 
 
-@map_attr(var1=Integer, var2=String)
+@attr(var1=Integer, var2=String)
 class SampleAttributeDictionary(AttributeDictionary):
 
     """Sample dictionary container with initialization."""
@@ -25,7 +25,7 @@ class SampleAttributeDictionary(AttributeDictionary):
         self.var3 = var3
 
 
-@map_attr(all=Float)
+@attr(all=Float)
 class SampleSortedList(SortedList):
 
     """Sample sorted list container."""

--- a/yorm/test/test_fake.py
+++ b/yorm/test/test_fake.py
@@ -15,8 +15,8 @@ class TestFake:
 
     """Integration tests with `yorm.fake` enabled."""
 
-    @yorm.map_attr(value=yorm.standard.Integer)
-    @yorm.store_instances("path/to/{self.name}.yml")
+    @yorm.attr(value=yorm.standard.Integer)
+    @yorm.sync("path/to/{self.name}.yml")
     class Sample:
 
         """Sample class for fake mapping."""

--- a/yorm/test/test_utilities.py
+++ b/yorm/test/test_utilities.py
@@ -57,9 +57,9 @@ class MockConverter4(MockConverter):
 
 @patch('yorm.common.write_text', Mock())
 @patch('yorm.common.stamp', Mock())
-class TestStore:
+class TestSyncObject:
 
-    """Unit tests for the `store` function."""
+    """Unit tests for the `sync_object` function."""
 
     class Sample:
 
@@ -67,57 +67,57 @@ class TestStore:
 
     def test_no_attrs(self):
         """Verify mapping can be enabled with no attributes."""
-        sample = utilities.store(self.Sample(), "sample.yml")
+        sample = utilities.sync(self.Sample(), "sample.yml")
         assert "sample.yml" == sample.yorm_path
         assert {} == sample.yorm_attrs
 
     def test_with_attrs(self):
         """Verify mapping can be enabled with with attributes."""
-        mapping = {'var1': MockConverter}
-        sample = utilities.store(self.Sample(), "sample.yml", mapping)
+        attrs = {'var1': MockConverter}
+        sample = utilities.sync(self.Sample(), "sample.yml", attrs)
         assert "sample.yml" == sample.yorm_path
         assert {'var1': MockConverter} == sample.yorm_attrs
 
     def test_multiple(self):
         """Verify mapping cannot be enabled twice."""
-        sample = utilities.store(self.Sample(), "sample.yml")
+        sample = utilities.sync(self.Sample(), "sample.yml")
         with pytest.raises(common.UseageError):
-            utilities.store(sample, "sample.yml")
+            utilities.sync(sample, "sample.yml")
 
     @patch('os.path.isfile', Mock(return_value=True))
     @patch('yorm.common.read_text', Mock(return_value="abc: 123"))
     def test_init_existing(self):
         """Verify an existing file is read."""
-        sample = utilities.store(self.Sample(), "sample.yml")
+        sample = utilities.sync(self.Sample(), "sample.yml")
         assert 123 == sample.abc
 
     def test_store(self):
         """Verify store is called when setting an attribute."""
-        mapping = {'var1': MockConverter}
-        sample = utilities.store(self.Sample(), "sample.yml", mapping)
+        attrs = {'var1': MockConverter}
+        sample = utilities.sync(self.Sample(), "sample.yml", attrs)
         with patch.object(sample, 'yorm_mapper') as mock_yorm_mapper:
             setattr(sample, 'var1', None)
         mock_yorm_mapper.retrieve.assert_never_called()
-        mock_yorm_mapper.store.assert_called_once_with(sample, mapping)
+        mock_yorm_mapper.sync.assert_called_once_with(sample, attrs)
 
-    def test_retrieve(self):
-        """Verify retrieve is called when getting an attribute."""
-        mapping = {'var1': MockConverter}
-        sample = utilities.store(self.Sample(), "sample.yml", mapping)
+    def test_fetch(self):
+        """Verify fetch is called when getting an attribute."""
+        attrs = {'var1': MockConverter}
+        sample = utilities.sync(self.Sample(), "sample.yml", attrs)
         with patch.object(sample, 'yorm_mapper') as mock_yorm_mapper:
             getattr(sample, 'var1', None)
-        mock_yorm_mapper.retrieve.assert_called_once_with(sample, mapping)
-        mock_yorm_mapper.store.assert_never_called()
+        mock_yorm_mapper.fetch.assert_called_once_with(sample, attrs)
+        mock_yorm_mapper.sync.assert_never_called()
 
 
 @patch('yorm.common.create_dirname', Mock())
 @patch('yorm.common.write_text', Mock())
 @patch('yorm.common.stamp', Mock())
-class TestStoreInstances:
+class TestSyncInstances:
 
-    """Unit tests for the `store_instances` decorator."""
+    """Unit tests for the `sync_instances` decorator."""
 
-    @utilities.store_instances("sample.yml")
+    @utilities.sync("sample.yml")
     class SampleDecorated:
 
         """Sample decorated class using a single path."""
@@ -125,7 +125,7 @@ class TestStoreInstances:
         def __repr__(self):
             return "<decorated {}>".format(id(self))
 
-    @utilities.store_instances("{UUID}.yml")
+    @utilities.sync("{UUID}.yml")
     class SampleDecoratedIdentifiers:
 
         """Sample decorated class using UUIDs for paths."""
@@ -133,7 +133,7 @@ class TestStoreInstances:
         def __repr__(self):
             return "<decorated w/ UUID {}>".format(id(self))
 
-    @utilities.store_instances("path/to/{n}.yml", {'n': 'name'})
+    @utilities.sync("path/to/{n}.yml", {'n': 'name'})
     class SampleDecoratedAttributes:
 
         """Sample decorated class using an attribute value for paths."""
@@ -144,7 +144,7 @@ class TestStoreInstances:
         def __repr__(self):
             return "<decorated w/ specified attributes {}>".format(id(self))
 
-    @utilities.store_instances("path/to/{self.name}.yml")
+    @utilities.sync("path/to/{self.name}.yml")
     class SampleDecoratedAttributesAutomatic:
 
         """Sample decorated class using an attribute value for paths."""
@@ -155,8 +155,7 @@ class TestStoreInstances:
         def __repr__(self):
             return "<decorated w/ automatic attributes {}>".format(id(self))
 
-    @utilities.store_instances("{self.a}/{self.b}/{c}.yml",
-                               {'self.b': 'b', 'c': 'c'})
+    @utilities.sync("{self.a}/{self.b}/{c}.yml", {'self.b': 'b', 'c': 'c'})
     class SampleDecoratedAttributesCombination:
 
         """Sample decorated class using an attribute value for paths."""
@@ -169,7 +168,7 @@ class TestStoreInstances:
         def __repr__(self):
             return "<decorated w/ attributes {}>".format(id(self))
 
-    @utilities.store_instances("sample.yml", attrs={'var1': MockConverter})
+    @utilities.sync("sample.yml", attrs={'var1': MockConverter})
     class SampleDecoratedWithAttributes:
 
         """Sample decorated class using a single path."""
@@ -227,62 +226,62 @@ class TestStoreInstances:
         with patch.object(sample, 'yorm_mapper') as mock_yorm_mapper:
             setattr(sample, 'var1', None)
         mock_yorm_mapper.retrieve.assert_never_called()
-        mock_yorm_mapper.store.assert_called_once_with(sample,
-                                                       sample.yorm_attrs)
+        mock_yorm_mapper.sync.assert_called_once_with(sample,
+                                                      sample.yorm_attrs)
 
-    def test_retrieve(self):
-        """Verify retrieve is called when getting an attribute."""
+    def test_fetch(self):
+        """Verify fetch is called when getting an attribute."""
         sample = self.SampleDecoratedWithAttributes()
         with patch.object(sample, 'yorm_mapper') as mock_yorm_mapper:
             getattr(sample, 'var1', None)
-        mock_yorm_mapper.retrieve.assert_called_once_with(sample,
-                                                          sample.yorm_attrs)
-        mock_yorm_mapper.store.assert_never_called()
+        mock_yorm_mapper.fetch.assert_called_once_with(sample,
+                                                       sample.yorm_attrs)
+        mock_yorm_mapper.sync.assert_never_called()
 
 
 @patch('yorm.common.write_text', Mock())
 @patch('yorm.common.stamp', Mock())
-class TestMapAttr:
+class TestAttr:
 
-    """Unit tests for the `map_attr` decorator."""
+    """Unit tests for the `attr` decorator."""
 
-    @utilities.map_attr(var1=MockConverter1, var2=MockConverter2)
-    @utilities.store_instances("sample.yml")
+    @utilities.attr(var1=MockConverter1, var2=MockConverter2)
+    @utilities.sync("sample.yml")
     class SampleDecoratedSingle:
 
-        """Sample decorated class using one `map_attr` decorator."""
+        """Sample decorated class using one `attr` decorator."""
 
-    @utilities.map_attr()
-    @utilities.map_attr(var1=MockConverter1)
-    @utilities.map_attr(var2=MockConverter2, var3=MockConverter3)
-    @utilities.store_instances("sample.yml")
+    @utilities.attr()
+    @utilities.attr(var1=MockConverter1)
+    @utilities.attr(var2=MockConverter2, var3=MockConverter3)
+    @utilities.sync("sample.yml")
     class SampleDecoratedMultiple:
 
-        """Sample decorated class using many `map_attr` decorators."""
+        """Sample decorated class using many `attr` decorators."""
 
-    @utilities.map_attr()
-    @utilities.map_attr(var1=MockConverter1)
-    @utilities.map_attr(var2=MockConverter2, var3=MockConverter3)
-    @utilities.store_instances("sample.yml", attrs={'var0': MockConverter0})
+    @utilities.attr()
+    @utilities.attr(var1=MockConverter1)
+    @utilities.attr(var2=MockConverter2, var3=MockConverter3)
+    @utilities.sync("sample.yml", attrs={'var0': MockConverter0})
     class SampleDecoratedCombo:
 
-        """Sample decorated class using `map_attr` and providing a mapping."""
+        """Sample decorated class using `attr` and providing a mapping."""
 
-    @utilities.store_instances("sample.yml", attrs={'var0': MockConverter0})
-    @utilities.map_attr(var1=MockConverter1)
+    @utilities.sync("sample.yml", attrs={'var0': MockConverter0})
+    @utilities.attr(var1=MockConverter1)
     class SampleDecoratedBackwards:
 
-        """Sample decorated class using one `map_attr` decorator."""
+        """Sample decorated class using one `attr` decorator."""
 
     def test_single(self):
-        """Verify `map_attr` can be applied once."""
+        """Verify `attr` can be applied once."""
         sample = self.SampleDecoratedSingle()
         expected = {'var1': MockConverter1,
                     'var2': MockConverter2}
         assert expected == sample.yorm_attrs
 
     def test_multiple(self):
-        """Verify `map_attr` can be applied many times."""
+        """Verify `attr` can be applied many times."""
         sample = self.SampleDecoratedMultiple()
         expected = {'var1': MockConverter1,
                     'var2': MockConverter2,
@@ -290,7 +289,7 @@ class TestMapAttr:
         assert expected == sample.yorm_attrs
 
     def test_combo(self):
-        """Verify `map_attr` can be applied an existing mapping."""
+        """Verify `attr` can be applied an existing mapping."""
         sample = self.SampleDecoratedCombo()
         expected = {'var0': MockConverter0,
                     'var1': MockConverter1,
@@ -299,7 +298,7 @@ class TestMapAttr:
         assert expected == sample.yorm_attrs
 
     def test_backwards(self):
-        """Verify `map_attr` can be applied before `store_instances`."""
+        """Verify `attr` can be applied before `sync`."""
         sample = self.SampleDecoratedBackwards()
         expected = {'var0': MockConverter0,
                     'var1': MockConverter1}

--- a/yorm/test/test_utilities.py
+++ b/yorm/test/test_utilities.py
@@ -97,8 +97,8 @@ class TestSyncObject:
         sample = utilities.sync(self.Sample(), "sample.yml", attrs)
         with patch.object(sample, 'yorm_mapper') as mock_yorm_mapper:
             setattr(sample, 'var1', None)
-        mock_yorm_mapper.retrieve.assert_never_called()
-        mock_yorm_mapper.sync.assert_called_once_with(sample, attrs)
+        mock_yorm_mapper.fetch.assert_never_called()
+        mock_yorm_mapper.store.assert_called_once_with(sample, attrs)
 
     def test_fetch(self):
         """Verify fetch is called when getting an attribute."""
@@ -107,7 +107,7 @@ class TestSyncObject:
         with patch.object(sample, 'yorm_mapper') as mock_yorm_mapper:
             getattr(sample, 'var1', None)
         mock_yorm_mapper.fetch.assert_called_once_with(sample, attrs)
-        mock_yorm_mapper.sync.assert_never_called()
+        mock_yorm_mapper.store.assert_never_called()
 
 
 @patch('yorm.common.create_dirname', Mock())
@@ -225,9 +225,9 @@ class TestSyncInstances:
         sample = self.SampleDecoratedWithAttributes()
         with patch.object(sample, 'yorm_mapper') as mock_yorm_mapper:
             setattr(sample, 'var1', None)
-        mock_yorm_mapper.retrieve.assert_never_called()
-        mock_yorm_mapper.sync.assert_called_once_with(sample,
-                                                      sample.yorm_attrs)
+        mock_yorm_mapper.fetch.assert_never_called()
+        mock_yorm_mapper.store.assert_called_once_with(sample,
+                                                       sample.yorm_attrs)
 
     def test_fetch(self):
         """Verify fetch is called when getting an attribute."""
@@ -236,7 +236,7 @@ class TestSyncInstances:
             getattr(sample, 'var1', None)
         mock_yorm_mapper.fetch.assert_called_once_with(sample,
                                                        sample.yorm_attrs)
-        mock_yorm_mapper.sync.assert_never_called()
+        mock_yorm_mapper.store.assert_never_called()
 
 
 @patch('yorm.common.write_text', Mock())

--- a/yorm/test/test_utilities.py
+++ b/yorm/test/test_utilities.py
@@ -169,7 +169,7 @@ class TestStoreInstances:
         def __repr__(self):
             return "<decorated w/ attributes {}>".format(id(self))
 
-    @utilities.store_instances("sample.yml", mapping={'var1': MockConverter})
+    @utilities.store_instances("sample.yml", attrs={'var1': MockConverter})
     class SampleDecoratedWithAttributes:
 
         """Sample decorated class using a single path."""
@@ -263,12 +263,12 @@ class TestMapAttr:
     @utilities.map_attr()
     @utilities.map_attr(var1=MockConverter1)
     @utilities.map_attr(var2=MockConverter2, var3=MockConverter3)
-    @utilities.store_instances("sample.yml", mapping={'var0': MockConverter0})
+    @utilities.store_instances("sample.yml", attrs={'var0': MockConverter0})
     class SampleDecoratedCombo:
 
         """Sample decorated class using `map_attr` and providing a mapping."""
 
-    @utilities.store_instances("sample.yml", mapping={'var0': MockConverter0})
+    @utilities.store_instances("sample.yml", attrs={'var0': MockConverter0})
     @utilities.map_attr(var1=MockConverter1)
     class SampleDecoratedBackwards:
 

--- a/yorm/utilities.py
+++ b/yorm/utilities.py
@@ -11,16 +11,33 @@ log = common.logger(__name__)
 UUID = 'UUID'
 
 
-def store(instance, path, mapping=None, auto=True):
+def sync(*args, **kwargs):
+    """Convenience function to forward calls based on arguments.
+
+    This function will call one of:
+
+    * `sync_object` - when given an unmapped object
+    * `sync_instances` - when used as the class decorator
+
+    Consult the signature of each call for more information.
+
+    """
+    if 'path_format' in kwargs or args and isinstance(args[0], str):
+        return sync_instances(*args, **kwargs)
+    else:
+        return sync_object(*args, **kwargs)
+
+
+def sync_object(instance, path, attrs=None, auto=True):
     """Enable YAML mapping on an object.
 
     :param instance: object to patch with YAML mapping behavior
     :param path: file path for dump/load
-    :param mapping: dictionary of attribute names mapped to converter classes
+    :param attrs: dictionary of attribute names mapped to converter classes
     :param auto: automatically store attribute to file
 
     """
-    mapping = mapping or {}
+    attrs = attrs or {}
 
     if isinstance(instance, Mappable):
         raise common.UseageError("{} is already mapped".format(repr(instance)))
@@ -31,7 +48,7 @@ def store(instance, path, mapping=None, auto=True):
 
     instance.__class__ = Mapped
 
-    instance.yorm_attrs = mapping or getattr(instance, 'yorm_attrs', mapping)
+    instance.yorm_attrs = attrs or getattr(instance, 'yorm_attrs', attrs)
     instance.yorm_path = path
     instance.yorm_mapper = Mapper(instance.yorm_path)
 
@@ -40,31 +57,31 @@ def store(instance, path, mapping=None, auto=True):
         if auto:
             instance.yorm_mapper.store(instance, instance.yorm_attrs)
     else:
-        instance.yorm_mapper.retrieve(instance, instance.yorm_attrs)
+        instance.yorm_mapper.fetch(instance, instance.yorm_attrs)
 
     instance.yorm_mapper.auto = auto
 
     return instance
 
 
-def store_instances(path_format, format_spec=None, mapping=None, auto=True):
+def sync_instances(path_format, format_spec=None, attrs=None, auto=True):
     """Class decorator to enable YAML mapping after instantiation.
 
     :param path_format: formatting string to create file paths for dump/load
     :param format_spec: dictionary to use for string formatting
-    :param mapping: dictionary of attribute names mapped to converter classes
+    :param attrs: dictionary of attribute names mapped to converter classes
     :param auto: automatically store attribute to file
 
     """
     format_spec = format_spec or {}
-    mapping = mapping or {}
+    attrs = attrs or {}
 
     def decorator(cls):
         """Class decorator."""
         if hasattr(cls, 'yorm_attrs'):
-            cls.yorm_attrs.update(mapping)
+            cls.yorm_attrs.update(attrs)
         else:
-            cls.yorm_attrs = mapping
+            cls.yorm_attrs = attrs
 
         class Mapped(Mappable, cls):
 
@@ -88,7 +105,7 @@ def store_instances(path_format, format_spec=None, mapping=None, auto=True):
                     if auto:
                         self.yorm_mapper.store(self, self.yorm_attrs)
                 else:
-                    self.yorm_mapper.retrieve(self, self.yorm_attrs)
+                    self.yorm_mapper.fetch(self, self.yorm_attrs)
 
                 self.yorm_mapper.auto = auto
 
@@ -97,7 +114,7 @@ def store_instances(path_format, format_spec=None, mapping=None, auto=True):
     return decorator
 
 
-def map_attr(**kwargs):
+def attr(**kwargs):
     """Class decorator to map attributes to converters.
 
     :param kwargs: keyword arguments mapping attribute name to converter class
@@ -112,3 +129,18 @@ def map_attr(**kwargs):
         return cls
 
     return decorator
+
+
+def update(instance):
+    """Synchronize changes between a mapped object and its file."""
+    log.critical(instance)
+
+
+def update_object(instance):
+    """Synchronize changes into a mapped object from its file."""
+    log.critical(instance)
+
+
+def update_file(instance):
+    """Synchronize changes into a mapped object's file."""
+    log.critical(instance)


### PR DESCRIPTION
After using the library for a while, I've decided on the following new names:

- [x] `sync` (takes `attrs` dictionary)
    - calls `sync_instances` or `sync_object` based on usage
- [x] `sync_instances` (takes `attrs` dictionary)
- [x] `sync_object` (takes `attrs` dictionary)
- [x] `attr`
- [x] `update` (takes `fetch` and `store` booleans)
  - calls `update_object` and/or `update_file` based on usage 
- [x] `update_object` (takes `force` boolean)
- [x] `update_file` 

Which requires:

- [x] updating code/tests
- [x] updating example
- [x] updating readme (compare to the template)
- [x] updating changelog
