### PR TITLE
Preserve decorated argument order

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Revision History
 
+## 0.7 (unreleased)
+
+- Now preserving order of `attr` decorators.
+- Now limiting `attr` decorator to a single argument.
+
 ## 0.6.1 (2015/02/23)
 
 - Fixed handling of `None` in `NullableString`.

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -70,7 +70,8 @@ class SampleStandardDecorated:
         return "<decorated {}>".format(id(self))
 
 
-@yorm.attr(status=Boolean, label=String)
+@yorm.attr(label=String)
+@yorm.attr(status=Boolean)
 class StatusDictionary(Dictionary):
     """Sample dictionary container."""
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -34,17 +34,21 @@ class SampleStandard:
         self.string = ""
         self.number_int = 0
         self.number_real = 0.0
-        self.true = True
-        self.false = False
+        self.truthy = True
+        self.falsey = False
         self.null = None
 
     def __repr__(self):
         return "<standard {}>".format(id(self))
 
 
-@yorm.attr(object=EmptyDictionary, array=IntegerList, string=String)
-@yorm.attr(number_int=Integer, number_real=Float)
-@yorm.attr(true=Boolean, false=Boolean)
+@yorm.attr(array=IntegerList)
+@yorm.attr(falsey=Boolean)
+@yorm.attr(number_int=Integer)
+@yorm.attr(number_real=Float)
+@yorm.attr(object=EmptyDictionary)
+@yorm.attr(string=String)
+@yorm.attr(truthy=Boolean)
 @yorm.sync("path/to/{self.category}/{self.name}.yml")
 class SampleStandardDecorated:
     """Sample class using standard attribute types."""
@@ -58,8 +62,8 @@ class SampleStandardDecorated:
         self.string = ""
         self.number_int = 0
         self.number_real = 0.0
-        self.true = True
-        self.false = False
+        self.truthy = True
+        self.falsey = False
         self.null = None
 
     def __repr__(self):
@@ -165,8 +169,8 @@ class TestStandard:
         assert "" == sample.string
         assert 0 == sample.number_int
         assert 0.0 == sample.number_real
-        assert True is sample.true
-        assert False is sample.false
+        assert True is sample.truthy
+        assert False is sample.falsey
         assert None is sample.null
 
         log.info("Changing object values...")
@@ -175,8 +179,8 @@ class TestStandard:
         sample.string = "Hello, world!"
         sample.number_int = 42
         sample.number_real = 4.2
-        sample.true = False
-        sample.false = True
+        sample.truthy = False
+        sample.falsey = True
 
         log.info("Checking file contents...")
         assert strip("""
@@ -184,24 +188,24 @@ class TestStandard:
         - 0
         - 1
         - 2
-        'false': true
+        falsey: true
         number_int: 42
         number_real: 4.2
         object: {}
         string: Hello, world!
-        'true': false
+        truthy: false
         """) == sample.__mapper__.text
 
         log.info("Changing file contents...")
         refresh_file_modification_times()
         sample.__mapper__.text = strip("""
         array: [4, 5, 6]
-        'false': null
+        falsey: null
         number_int: 42
         number_real: '4.2'
         object: {'status': false}
         string: "abc"
-        'true': null
+        truthy: null
         """)
 
         log.info("Checking object values...")
@@ -210,8 +214,8 @@ class TestStandard:
         assert "abc" == sample.string
         assert 42 == sample.number_int
         assert 4.2 == sample.number_real
-        assert False is sample.true
-        assert False is sample.false
+        assert False is sample.truthy
+        assert False is sample.falsey
 
     def test_function(self, tmpdir):
         """Verify standard attribute types dump/load correctly (function)."""
@@ -222,8 +226,8 @@ class TestStandard:
                  'string': String,
                  'number_int': Integer,
                  'number_real': Float,
-                 'true': Boolean,
-                 'false': Boolean}
+                 'truthy': Boolean,
+                 'falsey': Boolean}
         sample = yorm.sync(_sample, "path/to/directory/sample.yml", attrs)
         assert "path/to/directory/sample.yml" == sample.__mapper__.path
 
@@ -233,8 +237,8 @@ class TestStandard:
         assert "" == sample.string
         assert 0 == sample.number_int
         assert 0.0 == sample.number_real
-        assert True is sample.true
-        assert False is sample.false
+        assert True is sample.truthy
+        assert False is sample.falsey
         assert None is sample.null
 
         # change object values
@@ -243,8 +247,8 @@ class TestStandard:
         sample.string = "Hello, world!"
         sample.number_int = 42
         sample.number_real = 4.2
-        sample.true = None
-        sample.false = 1
+        sample.truthy = None
+        sample.falsey = 1
 
         # check file values
         assert strip("""
@@ -252,13 +256,13 @@ class TestStandard:
         - 1
         - 2
         - 3
-        'false': true
+        falsey: true
         number_int: 42
         number_real: 4.2
         object:
           status: false
         string: Hello, world!
-        'true': false
+        truthy: false
         """) == sample.__mapper__.text
 
     def test_function_to_json(self, tmpdir):
@@ -270,8 +274,8 @@ class TestStandard:
                  'string': String,
                  'number_int': Integer,
                  'number_real': Float,
-                 'true': Boolean,
-                 'false': Boolean}
+                 'truthy': Boolean,
+                 'falsey': Boolean}
         sample = yorm.sync(_sample, "path/to/directory/sample.json", attrs)
         assert "path/to/directory/sample.json" == sample.__mapper__.path
 
@@ -281,8 +285,8 @@ class TestStandard:
         assert "" == sample.string
         assert 0 == sample.number_int
         assert 0.0 == sample.number_real
-        assert True is sample.true
-        assert False is sample.false
+        assert True is sample.truthy
+        assert False is sample.falsey
         assert None is sample.null
 
         # change object values
@@ -291,8 +295,8 @@ class TestStandard:
         sample.string = "Hello, world!"
         sample.number_int = 42
         sample.number_real = 4.2
-        sample.true = None
-        sample.false = 1
+        sample.truthy = None
+        sample.falsey = 1
 
         # check file values
         assert strip("""
@@ -302,14 +306,14 @@ class TestStandard:
                 2,
                 3
             ],
-            "false": true,
+            "falsey": true,
             "number_int": 42,
             "number_real": 4.2,
             "object": {
                 "status": false
             },
             "string": "Hello, world!",
-            "true": false
+            "truthy": false
         }
         """, tabs=2, end='') == sample.__mapper__.text
 
@@ -419,16 +423,6 @@ class TestContainers:
         # check object types
         assert Object == sample.__mapper__.attrs['object']
         assert Object == sample.__mapper__.attrs['array']
-
-        # change object values
-        sample.object = None
-        sample.array = "abc"
-
-        # check file values
-        assert strip("""
-        array: abc
-        object: null
-        """) == sample.__mapper__.text
 
 
 class TestExtended:

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -24,9 +24,13 @@ class IntegerList(List):
     """Sample list container."""
 
 
-@yorm.attr(object=EmptyDictionary, array=IntegerList, string=String)
-@yorm.attr(number_int=Integer, number_real=Float)
-@yorm.attr(true=Boolean, false=Boolean)
+@yorm.attr(array=IntegerList)
+@yorm.attr(false=Boolean)
+@yorm.attr(number_int=Integer)
+@yorm.attr(number_real=Float)
+@yorm.attr(object=EmptyDictionary)
+@yorm.attr(string=String)
+@yorm.attr(true=Boolean)
 @yorm.sync("path/to/{self.category}/{self.name}.yml")
 class SampleStandardDecorated:
     """Sample class using standard attribute types."""

--- a/tests/test_nested_attributes.py
+++ b/tests/test_nested_attributes.py
@@ -23,8 +23,8 @@ class NestedList3(yorm.types.List):
         return "<nested-list-3 {}>".format((id(self)))
 
 
-@yorm.attr(number=yorm.types.Float)
 @yorm.attr(nested_list_3=NestedList3)
+@yorm.attr(number=yorm.types.Float)
 class NestedDictionary3(yorm.types.AttributeDictionary):
 
     def __init__(self):
@@ -57,8 +57,8 @@ class NestedDictionary2(yorm.types.AttributeDictionary):
         return "<nested-dictionary-2 {}>".format((id(self)))
 
 
-@yorm.attr(number=yorm.types.Float)
 @yorm.attr(nested_list_2=NestedList2)
+@yorm.attr(number=yorm.types.Float)
 class NestedDictionary(yorm.types.AttributeDictionary):
 
     def __init__(self):
@@ -77,7 +77,8 @@ class NestedList(yorm.types.List):
         return "<nested-list {}>".format((id(self)))
 
 
-@yorm.attr(nested_list=NestedList, nested_dict=NestedDictionary)
+@yorm.attr(nested_dict=NestedDictionary)
+@yorm.attr(nested_list=NestedList)
 @yorm.sync("sample.yml")
 class Top:
 

--- a/tests/test_ordering.py
+++ b/tests/test_ordering.py
@@ -1,0 +1,39 @@
+# pylint: disable=redefined-outer-name
+
+import pytest
+
+import yorm
+
+from . import strip
+
+
+@yorm.attr(string=yorm.types.String)
+@yorm.attr(number_int=yorm.types.Integer)
+@yorm.attr(number_real=yorm.types.Float)
+@yorm.attr(truthy=yorm.types.Boolean)
+@yorm.attr(falsey=yorm.types.Boolean)
+@yorm.sync("sample.yml")
+class Sample:
+    """Sample class with ordered attributes."""
+
+
+@pytest.fixture
+def sample(tmpdir):
+    tmpdir.chdir()
+    return Sample()
+
+
+def test_attribute_order_is_maintained(sample):
+    sample.string = "Hello, world!"
+    sample.number_int = 42
+    sample.number_real = 4.2
+    sample.truthy = False
+    sample.falsey = True
+
+    assert strip("""
+    string: Hello, world!
+    number_int: 42
+    number_real: 4.2
+    truthy: false
+    falsey: true
+    """) == sample.__mapper__.text

--- a/yorm/__init__.py
+++ b/yorm/__init__.py
@@ -3,7 +3,7 @@
 import sys
 
 __project__ = 'YORM'
-__version__ = '0.6.1'
+__version__ = '0.7.dev1'
 
 VERSION = __project__ + '-' + __version__
 

--- a/yorm/common.py
+++ b/yorm/common.py
@@ -20,7 +20,7 @@ OVERRIDE_MESSAGE = "Method must be implemented in subclasses"
 
 verbosity = 0  # global verbosity setting for controlling string formatting
 
-attrs = collections.defaultdict(dict)
+attrs = collections.defaultdict(collections.OrderedDict)
 
 
 # LOGGING ######################################################################

--- a/yorm/mapper.py
+++ b/yorm/mapper.py
@@ -227,7 +227,7 @@ class Mapper:
         log.info("Storing %r to %s...", self._obj, prefix(self))
 
         # Format the data items
-        data = {}
+        data = self.attrs.__class__()
         for name, converter in self.attrs.items():
             try:
                 value = getattr(self._obj, name)

--- a/yorm/test/test_types_containers.py
+++ b/yorm/test/test_types_containers.py
@@ -25,7 +25,8 @@ class SampleDictionary(Dictionary):
     """Sample dictionary container."""
 
 
-@attr(var1=Integer, var2=String)
+@attr(var1=Integer)
+@attr(var2=String)
 class SampleDictionaryWithInitialization(Dictionary):
 
     """Sample dictionary container with initialization."""

--- a/yorm/test/test_types_extended.py
+++ b/yorm/test/test_types_extended.py
@@ -54,7 +54,8 @@ def describe_markdown():
 
 def describe_attribute_dictionary():
 
-    @attr(var1=Integer, var2=String)
+    @attr(var1=Integer)
+    @attr(var2=String)
     class SampleAttributeDictionary(AttributeDictionary):
         """Sample attribute dictionary."""
 

--- a/yorm/types/_representers.py
+++ b/yorm/types/_representers.py
@@ -1,0 +1,30 @@
+"""Custom YAML representers."""
+
+from collections import OrderedDict
+
+import yaml
+
+
+class LiteralString(str):
+    """Custom type for strings which should be dumped in the literal style."""
+
+
+def represent_literalstring(dumper, data):
+    return dumper.represent_scalar('tag:yaml.org,2002:str', data,
+                                   style='|' if data else '')
+
+
+def represent_ordereddict(dumper, data):
+    value = []
+
+    for item_key, item_value in data.items():
+        node_key = dumper.represent_data(item_key)
+        node_value = dumper.represent_data(item_value)
+
+        value.append((node_key, node_value))
+
+    return yaml.nodes.MappingNode('tag:yaml.org,2002:map', value)
+
+
+yaml.add_representer(OrderedDict, represent_ordereddict)
+yaml.add_representer(LiteralString, represent_literalstring)

--- a/yorm/types/extended.py
+++ b/yorm/types/extended.py
@@ -2,10 +2,9 @@
 
 import re
 
-import yaml
-
 from .standard import String, Integer, Float, Boolean
 from .containers import Dictionary, List
+from ._representers import LiteralString
 
 
 # NULLABLE BUILTINS ############################################################
@@ -36,18 +35,6 @@ class NullableBoolean(Boolean):
 
 
 # CUSTOM TYPES #################################################################
-
-
-class _Literal(str):
-    """Custom type for strings which should be dumped in the literal style."""
-
-    @staticmethod
-    def representer(dumper, data):
-        """Return a custom dumper that formats `str` in the literal style."""
-        return dumper.represent_scalar('tag:yaml.org,2002:str', data,
-                                       style='|' if data else '')
-
-yaml.add_representer(_Literal, _Literal.representer)
 
 
 class Markdown(String):
@@ -102,7 +89,7 @@ class Markdown(String):
         value = String.to_value(obj)
         data = String.to_data(value)
         split = cls._split(data)
-        return _Literal(split)
+        return LiteralString(split)
 
     @classmethod
     def _join(cls, text):

--- a/yorm/utilities.py
+++ b/yorm/utilities.py
@@ -1,6 +1,7 @@
 """Functions and decorators."""
 
 import uuid
+from collections import OrderedDict
 
 from . import common, exceptions
 from .bases.mappable import patch_methods
@@ -44,7 +45,7 @@ def sync_object(instance, path, attrs=None, existing=None, **kwargs):
 
     patch_methods(instance)
 
-    attrs = attrs or common.attrs[instance.__class__]
+    attrs = _ordered(attrs) or common.attrs[instance.__class__]
     mapper = Mapper(instance, path, attrs, **kwargs)
     common.set_mapper(instance, mapper)
     _check_existance(mapper, existing)
@@ -70,7 +71,7 @@ def sync_instances(path_format, format_spec=None, attrs=None, **kwargs):
 
     """
     format_spec = format_spec or {}
-    attrs = attrs or {}
+    attrs = attrs or OrderedDict()
 
     def decorator(cls):
         """Class decorator to map instances to files.."""
@@ -90,11 +91,10 @@ def sync_instances(path_format, format_spec=None, attrs=None, **kwargs):
                 format_values[UUID] = uuid.uuid4().hex
             format_values['self'] = self
 
+            common.attrs[cls].update(attrs)
+            common.attrs[cls].update(common.attrs[self.__class__])
             path = path_format.format(**format_values)
-            attrs.update(common.attrs[self.__class__])
-            attrs.update(common.attrs[cls])
-
-            sync_object(self, path, attrs, **kwargs)
+            sync_object(self, path, **kwargs)
 
         modified_init.__doc__ = init.__doc__
         cls.__init__ = modified_init
@@ -112,7 +112,11 @@ def attr(**kwargs):
     """
     def decorator(cls):
         """Class decorator."""
+        previous = common.attrs[cls]
+        common.attrs[cls] = OrderedDict()
         for name, converter in kwargs.items():
+            common.attrs[cls][name] = converter
+        for name, converter in previous.items():
             common.attrs[cls][name] = converter
 
         return cls
@@ -180,6 +184,13 @@ def update_file(instance, existing=None, force=True):
 def synced(obj):
     """Determine if an object is already mapped to a file."""
     return bool(common.get_mapper(obj))
+
+
+def _ordered(data):
+    """Sort a dictionary-like object by key."""
+    if data is None:
+        return None
+    return OrderedDict(sorted(data.items(), key=lambda pair: pair[0]))
 
 
 def _check_base(obj, mappable=True):

--- a/yorm/utilities.py
+++ b/yorm/utilities.py
@@ -110,6 +110,9 @@ def attr(**kwargs):
     :param kwargs: keyword arguments mapping attribute name to converter class
 
     """
+    if len(kwargs) != 1:
+        raise ValueError("Single attribute required: {}".format(kwargs))
+
     def decorator(cls):
         """Class decorator."""
         previous = common.attrs[cls]


### PR DESCRIPTION
- [x] Add a separate integration test
- [ ] Split out decorators into a module

